### PR TITLE
Missing reg fix

### DIFF
--- a/F4RegPath.py
+++ b/F4RegPath.py
@@ -11,7 +11,7 @@ from tkinter import ttk
 import tkinter.filedialog
 import webbrowser
 
-version = "0.0.2 alpha"
+version = "0.0.4 alpha"
 
 HelpMsg = """Select the version. Press Change to change the installation path in the registry, or DELETE to delete the registry entry.
 
@@ -82,7 +82,7 @@ def GetPathsFromReg():
                 winreg.CloseKey(subKeyHandle)
             i = i + 1
     except OSError:
-        tk.messagebox.showerror(title="Registry Error", message="Error while querying registry. Perhaps this is a permission issue. Perhaps BMS was never installed.")
+        tk.messagebox.showerror(title="Registry Error", message="No traces of a Falcon BMS installation were found. Perhaps this is a permissions issue. Perhaps BMS has been uninstalled or was never installed.")
     finally:
         if(keyHandle):
             winreg.CloseKey(keyHandle)

--- a/F4RegPath.py
+++ b/F4RegPath.py
@@ -82,7 +82,7 @@ def GetPathsFromReg():
                 winreg.CloseKey(subKeyHandle)
             i = i + 1
     except OSError:
-        tk.messagebox.showerror(title="Registry Error", message="No traces of a Falcon BMS installation were found. Perhaps this is a permissions issue. Perhaps BMS has been uninstalled or was never installed.")
+        tk.messagebox.showerror(title="Registry Error", message="No traces of a Falcon BMS installation were found. Perhaps this is a permissions issue. Perhaps BMS has been uninstalled properly or was never installed.")
     finally:
         if(keyHandle):
             winreg.CloseKey(keyHandle)

--- a/F4RegPath.py
+++ b/F4RegPath.py
@@ -63,6 +63,8 @@ def deleteVersionFromReg(version):
 
 def GetPathsFromReg():
     arr = []
+    regHandle = None
+    keyHandle = None
     try:
         regHandle = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
         keyHandle = winreg.OpenKey(regHandle, baseSubKey)
@@ -82,8 +84,10 @@ def GetPathsFromReg():
     except OSError:
         tk.messagebox.showerror(title="Registry Error", message="Error while querying registry. Perhaps this is a permission issue. Perhaps BMS was never installed.")
     finally:
-        winreg.CloseKey(keyHandle)
-        winreg.CloseKey(regHandle)
+        if(keyHandle):
+            winreg.CloseKey(keyHandle)
+        if(regHandle):
+            winreg.CloseKey(regHandle)
         return arr
 
 def RefreshTree():

--- a/makeexe.cmd
+++ b/makeexe.cmd
@@ -1,0 +1,2 @@
+@echo off
+pyinstaller --windowed --uac-admin --icon=icons8-fighter-jet-100.png --add-data ".\*png;." --onefile F4RegPath.py


### PR DESCRIPTION
- Addressed issue https://github.com/BibleClinger/F4RegPath/issues/2 raised by ranXeron, in which the program would crash when the Benchmark Sims registry key was missing. Now the user is correctly informed that there is no Falcon installation found, and the error message has been further clarified. (At this point, the program is not needed by the user.)
- Added makeexe.cmd for programmer convenience. It runs the recommended pyinstaller command.
- Version number is finally correct on this branch.
